### PR TITLE
Add GET /api/:id route to fetch a single startup by ID

### DIFF
--- a/controllers/getSingleData.js
+++ b/controllers/getSingleData.js
@@ -1,0 +1,10 @@
+import { startups } from "../data/data.js";
+
+export const getSingleData = (req, res) => {
+  const { id } = req.params;
+  const startup = startups.find((item) => item.id === Number(id));
+  if (!startup) {
+    return res.status(404).json({ message: `No startup with id:${id} Found` });
+  }
+  return res.json(startup);
+};

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -1,9 +1,10 @@
-import express from 'express'
-import { getAllData } from '../controllers/getAllData.js'
-import { getDataByPathParams } from '../controllers/getDataByPathParams.js'
+import express from "express";
+import { getAllData } from "../controllers/getAllData.js";
+import { getDataByPathParams } from "../controllers/getDataByPathParams.js";
+import { getSingleData } from "../controllers/getSingleData.js";
 
-export const apiRouter = express.Router()
+export const apiRouter = express.Router();
 
-apiRouter.get('/', getAllData)
-
-apiRouter.get('/:field/:term', getDataByPathParams)
+apiRouter.get("/", getAllData);
+apiRouter.get("/:id", getSingleData);
+apiRouter.get("/:field/:term", getDataByPathParams);


### PR DESCRIPTION
- Uses req.params.id to fetch a single startup by ID
- Returns 404 if not found